### PR TITLE
Small README fix regarding github url and test runner path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 
 ### Get GeoCouch:
 
-    git clone https://github.com/couchone/geocouch.git
+    git clone https://github.com/couchbase/geocouch.git
     cd geocouch
 
 ### Compilation
@@ -47,7 +47,7 @@ over (from `<geocouch>/share/www/script/test` to
 
     cp <geocouch>/share/www/script/test/* <vanilla-couch>/share/www/script/test/
 
-Add the test to `<vanilla-couch>/share/www/script/test/couch_tests.js`
+Add the test to `<vanilla-couch>/share/www/script/couch_tests.js`
 
     loadTest("spatial.js");
     loadTest("list_spatial.js");


### PR DESCRIPTION
Old repository does not work.
couchdb/www/script/tests/couch_tests.js -> couchdb/www/script/couch_tests.js

Just found out @pgiraud did the same fix.
